### PR TITLE
fix severity field handling

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -119,13 +119,13 @@ func (h *Handler) addTimestamp(ctx context.Context, l *goldjson.LineWriter, r *s
 func (h *Handler) addSeverity(ctx context.Context, l *goldjson.LineWriter, r *slog.Record) {
 	switch {
 	case r.Level >= slog.LevelError:
-		l.AddUint64(fieldSeverity, severityError)
+		l.AddString(fieldSeverity, "ERROR")
 	case r.Level >= slog.LevelWarn:
-		l.AddUint64(fieldSeverity, severityWarn)
+		l.AddString(fieldSeverity, "WARN")
 	case r.Level >= slog.LevelInfo:
-		l.AddUint64(fieldSeverity, severityInfo)
+		l.AddString(fieldSeverity, "INFO")
 	default:
-		l.AddUint64(fieldSeverity, severityDebug)
+		l.AddString(fieldSeverity, "DEBUG")
 	}
 }
 
@@ -264,13 +264,6 @@ const (
 	fieldTraceSpanID    = "logging.googleapis.com/spanId"
 	fieldTraceSampled   = "logging.googleapis.com/trace_sampled"
 	fieldLabels         = "logging.googleapis.com/labels"
-)
-
-const (
-	severityError = 500
-	severityWarn  = 400
-	severityInfo  = 300
-	severityDebug = 200
 )
 
 func cloneSlice[T any](slice []T, extraCap int) []T {

--- a/handler_test.go
+++ b/handler_test.go
@@ -76,23 +76,23 @@ func TestHandler(t *testing.T) {
 		tests := []struct {
 			name     string
 			level    slog.Level
-			expected int
+			expected string
 		}{
-			{"debug", slog.LevelDebug, 200},
-			{"info", slog.LevelInfo, 300},
-			{"warn", slog.LevelWarn, 400},
-			{"error", slog.LevelError, 500},
-			{"below debug", slog.LevelDebug - 1, 200},
-			{"below info", slog.LevelInfo - 1, 200},
-			{"below warn", slog.LevelWarn - 1, 300},
-			{"below error", slog.LevelError - 1, 400},
-			{"above error", slog.LevelError + 1, 500},
+			{"debug", slog.LevelDebug, "DEBUG"},
+			{"info", slog.LevelInfo, "INFO"},
+			{"warn", slog.LevelWarn, "WARN"},
+			{"error", slog.LevelError, "ERROR"},
+			{"below debug", slog.LevelDebug - 1, "DEBUG"},
+			{"below info", slog.LevelInfo - 1, "DEBUG"},
+			{"below warn", slog.LevelWarn - 1, "INFO"},
+			{"below error", slog.LevelError - 1, "WARN"},
+			{"above error", slog.LevelError + 1, "ERROR"},
 		}
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				type Entry struct {
-					Severity int `json:"severity"`
+					Severity string `json:"severity"`
 				}
 				ctx := context.Background()
 				var capture slogtest.Capture[Entry]


### PR DESCRIPTION
The documentation on GCP structured logging via a logging agent states the following for the severity field[^1]:

> The Logging agent attempts to match a variety of common severity strings, which includes the list of LogSeverity strings recognized by the Logging API.

[^1]: https://cloud.google.com/logging/docs/structured-logging#structured_logging_special_fields

We are currently passing the integer LogEntry severity values directly, however, rather than the string values that logging agent expects. Fix that by using the string values instead.

---

This PR fixes the same issue as #3, but it also updates the unit tests and doesn't make unrelated changes. Just like @ammario, we are also using Cloud Run instead of GKE. I don't know what format GKE requires.